### PR TITLE
166-pkg_competences__v1-cc1-db-q3-NiveauCompetences

### DIFF
--- a/app/app/Models/pkg_competences/NiveauCompetence.php
+++ b/app/app/Models/pkg_competences/NiveauCompetence.php
@@ -18,6 +18,6 @@ class NiveauCompetence extends Model
     ];
     public function Competence()
     {
-        return $this->belongsTo(Competence::class);
+        return $this->belongsTo(Competence::class, 'competence_id');
     }
 }

--- a/app/app/Models/pkg_competences/NiveauCompetence.php
+++ b/app/app/Models/pkg_competences/NiveauCompetence.php
@@ -11,4 +11,13 @@ use Illuminate\Database\Eloquent\Model;
 class NiveauCompetence extends Model
 {
     use HasFactory;
+    protected $fillable = [
+        'nom',
+        'description',
+        'competence_id',
+    ];
+    public function Competence()
+    {
+        return $this->belongsTo(Competence::class);
+    }
 }

--- a/app/database/data/pkg_competences/NiveauCompetences.csv
+++ b/app/database/data/pkg_competences/NiveauCompetences.csv
@@ -1,0 +1,4 @@
+nom,description
+imiter,Capacité d'imiter les actions comportements ou modèles existants.
+adapter,Capacité de s'adapter aux nouvelles situations et de modifier son comportement en conséquence.
+transposer,Capacité de transférer des connaissances ou des compétences d'un contexte à un autre.

--- a/app/database/data/pkg_competences/NiveauCompetences.csv
+++ b/app/database/data/pkg_competences/NiveauCompetences.csv
@@ -1,4 +1,4 @@
-nom,description
-imiter,Capacité d'imiter les actions comportements ou modèles existants.
-adapter,Capacité de s'adapter aux nouvelles situations et de modifier son comportement en conséquence.
-transposer,Capacité de transférer des connaissances ou des compétences d'un contexte à un autre.
+nom,description,competence_id
+imiter,Capacité d'imiter les actions comportements ou modèles existants.,1
+adapter,Capacité de s'adapter aux nouvelles situations et de modifier son comportement en conséquence.,1
+transposer,Capacité de transférer des connaissances ou des compétences d'un contexte à un autre.,1

--- a/app/database/migrations/pkg_competences/2024_05_22_082058_add_nom_and_description_to_niveau_competences_table.php
+++ b/app/database/migrations/pkg_competences/2024_05_22_082058_add_nom_and_description_to_niveau_competences_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('niveau_competences', function (Blueprint $table) {
+            $table->string('nom');
+            $table->string('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('niveau_competences', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/app/database/migrations/pkg_competences/2024_05_22_082058_add_nom_and_description_to_niveau_competences_table.php
+++ b/app/database/migrations/pkg_competences/2024_05_22_082058_add_nom_and_description_to_niveau_competences_table.php
@@ -14,6 +14,8 @@ return new class extends Migration
         Schema::table('niveau_competences', function (Blueprint $table) {
             $table->string('nom');
             $table->string('description');
+            $table->unsignedBigInteger('competence_id');
+            $table->foreign('competence_id')->references('id')->on('competences')->onDelete('cascade');
         });
     }
 

--- a/app/database/seeders/AutorisationsSeeder.php
+++ b/app/database/seeders/AutorisationsSeeder.php
@@ -27,8 +27,8 @@ class AutorisationsSeeder extends Seeder
     {
         return [
             RoleSeeder::class,
-            ActionSeeder::class,
             ControllerSeeder::class,
+            ActionSeeder::class,
             
 
         ];

--- a/app/database/seeders/CompetencesSeeder.php
+++ b/app/database/seeders/CompetencesSeeder.php
@@ -6,8 +6,8 @@ use Illuminate\Database\Seeder;
 use Symfony\Component\Uid\NilUuid;
 
 use Database\Seeders\pkg_competences\{
-    CompetenceSeeder ,
     NiveauCompetencesSeeder,
+    CompetenceSeeder ,
     CategorieTechnologiesSeeder ,
 };
 
@@ -23,8 +23,8 @@ class CompetencesSeeder extends Seeder
     public static function Classes(): array
     {
         return [
-            CompetenceSeeder::class,
             NiveauCompetencesSeeder::class,
+            CompetenceSeeder::class,
             CategorieTechnologiesSeeder::class,
         ];
     }

--- a/app/database/seeders/DatabaseSeeder.php
+++ b/app/database/seeders/DatabaseSeeder.php
@@ -30,15 +30,15 @@ class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        // $this->call(AutorisationsSeeder::class);
-        // $this->call(UserSeeder::class);
-        // $this->call(CompetencesSeeder::class);
-        // $this->call(NotificationsSeeder::class);
-        // $this->call(RHSeeder::class);
-        // $this->call(GestionProjetsSeeder::class);
-        // $this->call(ProjetsSeeder::class);
+        $this->call(AutorisationsSeeder::class);
+        $this->call(UserSeeder::class);
+        $this->call(CompetencesSeeder::class);
+        $this->call(NotificationsSeeder::class);
+        $this->call(RHSeeder::class);
+        $this->call(GestionProjetsSeeder::class);
+        $this->call(ProjetsSeeder::class);
         $this->call(RealisationProjetSeeder::class);
-        // $this->call(PostsSeeder::class);
+        $this->call(PostsSeeder::class);
        
       
     

--- a/app/database/seeders/pkg_competences/NiveauCompetencesSeeder.php
+++ b/app/database/seeders/pkg_competences/NiveauCompetencesSeeder.php
@@ -2,8 +2,10 @@
 
 namespace Database\Seeders\pkg_competences;
 
+use App\Models\pkg_competences\NiveauCompetence;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class NiveauCompetencesSeeder extends Seeder
 {
@@ -12,6 +14,23 @@ class NiveauCompetencesSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        Schema::disableForeignKeyConstraints();
+        NiveauCompetence::truncate();
+        Schema::enableForeignKeyConstraints();
+
+        $csvFile = fopen(base_path("database/data/pkg_competences/NiveauCompetences.csv"), "r");
+        $firstline = true;
+        $i = 0;
+        while (($data = fgetcsv($csvFile)) !== FALSE) {
+            if (!$firstline) {
+                NiveauCompetence::create([
+                    "nom"=>$data['0'],
+                    "description" =>$data['1']
+                ]);
+            }
+            $firstline = false;
+        }
+
+        fclose($csvFile);
     }
 }

--- a/app/database/seeders/pkg_competences/NiveauCompetencesSeeder.php
+++ b/app/database/seeders/pkg_competences/NiveauCompetencesSeeder.php
@@ -24,8 +24,9 @@ class NiveauCompetencesSeeder extends Seeder
         while (($data = fgetcsv($csvFile)) !== FALSE) {
             if (!$firstline) {
                 NiveauCompetence::create([
-                    "nom"=>$data['0'],
-                    "description" =>$data['1']
+                    "competence_id,"=>$data['0'],
+                    "nom"=>$data['1'],
+                    "description" =>$data['2']
                 ]);
             }
             $firstline = false;

--- a/docs/pkg_competences/réalisation/CréationDeLaBaseDeDonnées.md
+++ b/docs/pkg_competences/réalisation/CréationDeLaBaseDeDonnées.md
@@ -27,7 +27,6 @@ php artisan make:migration add_description_nom_to_competences_table --table=comp
  php artisan make:migration add_nom_and_description_to_niveau_competences_table --table=niveau_competences
 
 ````
-
 ### Migrate
 
 

--- a/docs/pkg_competences/réalisation/CréationDeLaBaseDeDonnées.md
+++ b/docs/pkg_competences/réalisation/CréationDeLaBaseDeDonnées.md
@@ -24,6 +24,7 @@ php artisan make:model Technologie -m
 ````bash
 
 php artisan make:migration add_description_nom_to_competences_table --table=competences
+ php artisan make:migration add_nom_and_description_to_niveau_competences_table --table=niveau_competences
 
 ````
 


### PR DESCRIPTION
- feat: Add 'nom' and 'description' columns to 'niveau_competences' table
- feat: Add 'nom' and 'description' columns to 'niveau_competences' table
- feat: Add 'nom' and 'description' columns to 'niveau_competences' table
- feat: Update seeders for Autorisations, Competences, and DatabaseSeeder
- feat: Add 'nom' and 'description' columns to 'niveau_competences' table
- feat: Add 'nom' and 'description' columns to 'niveau_competences' table
- feat: Add 'competence_id' column to 'NiveauCompetences.csv' and 'NiveauCompetencesSeeder.php'
- feat: Update 'NiveauCompetence' model to use 'competence_id' as foreign key
